### PR TITLE
Fix OSX version detection.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-OSX_VERSION="$(sw_vers -productVersion | sed -E "s/^[0-9]+\.([0-9]+)/\\1/")"
+OSX_VERSION="$(sw_vers -productVersion | sed -E "s/^[0-9]+\.([0-9]+)(\..+)?/\\1/")"
 
 # Install Karabiner if it isn't installed, but homebrew and cask are.
 if [[ "$(type -P brew)" && "$(brew tap | awk '/cask/')" ]]; then


### PR DESCRIPTION
Things are broken bc the last bit of the version is not accounted for:
```
$ sw_vers -productVersion
10.14.5
```
Here, we'd want `14` but we get `14.5`. This breaks b/c bash can't do floating point numerical comparisons.

Fix just ignores anything after the second `.` if there is anything.